### PR TITLE
Holy Days Issue Bugfix

### DIFF
--- a/src/BadiNodaTime/BadiYearInfo.cs
+++ b/src/BadiNodaTime/BadiYearInfo.cs
@@ -135,7 +135,7 @@ namespace BadiNodaTime
       return final
         .Where(sd =>
              holyDaysWanted == HolyDayCode._NoCode_
-          || !sd.DayType.HasFlag(SpecialDayType.HolyDay_WorkSuspended | SpecialDayType.HolyDay_Other)
+          || ((sd.DayType != SpecialDayType.HolyDay_WorkSuspended) && (sd.DayType != SpecialDayType.HolyDay_Other))
           || sd.DayCode.HasFlag(holyDaysWanted))
         .OrderBy(sd => sd.Date.LocalDate.DayOfYear)
         .ToList();

--- a/src/BadiNodaTimeTest/ResourceTests.cs
+++ b/src/BadiNodaTimeTest/ResourceTests.cs
@@ -44,7 +44,17 @@ namespace BadiNodaTimeTest
       _resolver.GetString("HolyDay_" + code).ShouldEqual(name);
 
       var yi = new BadiYearInfo(174);
-      var holyDay = yi.GetSpecialDays(SpecialDayType.HolyDay_Other, code).First();
+      SpecialDayType specialDayType = new SpecialDayType();
+      if (code == HolyDayCode.BirthBab)
+      {
+        specialDayType = SpecialDayType.HolyDay_WorkSuspended;
+      }
+      else if (code == HolyDayCode.AscAbdul)
+      {
+        specialDayType = SpecialDayType.HolyDay_Other;
+      }
+
+      var holyDay = yi.GetSpecialDays(specialDayType, code).First();
 
       if (holyDay.TimeCode != SpecialTimeCode._NoCode_)
       {

--- a/src/BadiNodaTimeTest/YearInfoTests.cs
+++ b/src/BadiNodaTimeTest/YearInfoTests.cs
@@ -103,5 +103,17 @@ namespace BadiNodaTimeTest
       hd2.TimeCode.ShouldEqual(SpecialTimeCode.H01);
       hd2.DayCode.ShouldEqual(HolyDayCode.AscAbdul);
     }
+
+    [Fact]
+    public void GetSpecialDays_HolyDaysWanted()
+    {
+        var yearInfo = new BadiYearInfo(174);
+
+        var specialDaysList = yearInfo.GetSpecialDays(SpecialDayType.HolyDay_WorkSuspended, HolyDayCode.NawRuz);
+        specialDaysList.Count().ShouldEqual(1);
+
+        specialDaysList = yearInfo.GetSpecialDays(SpecialDayType.HolyDay_WorkSuspended, HolyDayCode.Ridvan1);
+        specialDaysList.Count().ShouldEqual(1);
+    }
   }
 }


### PR DESCRIPTION
Fix for specific Holy Day not getting pulled back when code provided to GetSpecialDays function. HasFlags() check was previously failing, replaced with not-null check instead.

Fix for related Resources test that was pulling back incorrect Holy Day previously. Special Day code was passed incorrectly for Birth of the Bab test case.

Added new YearInfo test to check bugfix.